### PR TITLE
support math fenced code blocks

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -14,3 +14,5 @@ export { default as Prism } from "https://esm.sh/prismjs@1.27.0";
 export { default as sanitizeHtml } from "https://esm.sh/sanitize-html@2.7.0";
 
 export { escape as htmlEscape } from "https://esm.sh/he@1.2.0";
+
+export { default as katex } from "https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.mjs";

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,11 @@
-import { emojify, htmlEscape, Marked, Prism, sanitizeHtml } from "./deps.ts";
+import {
+  emojify,
+  htmlEscape,
+  katex,
+  Marked,
+  Prism,
+  sanitizeHtml,
+} from "./deps.ts";
 import { CSS } from "./style.js";
 export { CSS };
 
@@ -16,6 +23,12 @@ class Renderer extends Marked.Renderer {
   code(code: string, language?: string) {
     // a language of `ts, ignore` should really be `ts`
     language = language?.split(",")?.[0];
+
+    // transform math code blocks into HTML+MathML
+    // https://github.blog/changelog/2022-06-28-fenced-block-syntax-for-mathematical-expressions/
+    if (language === "math") {
+      return htmlEscape(katex.renderToString(code));
+    }
     const grammar =
       language && Object.hasOwnProperty.call(Prism.languages, language)
         ? Prism.languages[language]


### PR DESCRIPTION
Before merging
- [ ] Add KaTeX style sheet and fonts to enable proper rendering. This should probably be opt-in given the increase in bundle size.

For later

- [ ] Support `$` and `$$` math syntaxes.

Related #5 
