### PR TITLE
Whitelist markdown elements for better github md parity

### DIFF
--- a/example/content.md
+++ b/example/content.md
@@ -13,6 +13,15 @@
 
 ~~Some strikethrough `text`~~
 
+<details>
+  <summary>Summary</summary>
+  <p>Some Details
+
+  **even more details**
+
+  </p>
+</details>
+
 # Deno
 
 [![Build Status - Cirrus][]][Build status] [![Twitter handle][]][Twitter badge]

--- a/example/content.md
+++ b/example/content.md
@@ -11,6 +11,8 @@
 + world
 ```
 
+~~Some strikethrough `text`~~
+
 # Deno
 
 [![Build Status - Cirrus][]][Build status] [![Twitter handle][]][Twitter badge]

--- a/mod.ts
+++ b/mod.ts
@@ -59,6 +59,7 @@ export function render(markdown: string, opts: RenderOptions = {}): string {
     "path",
     "figure",
     "figcaption",
+    "del"
   ]);
   if (opts.allowIframes) {
     allowedTags.push("iframe");

--- a/mod.ts
+++ b/mod.ts
@@ -59,7 +59,9 @@ export function render(markdown: string, opts: RenderOptions = {}): string {
     "path",
     "figure",
     "figcaption",
-    "del"
+    "del",
+    "details",
+    "summary"
   ]);
   if (opts.allowIframes) {
     allowedTags.push("iframe");


### PR DESCRIPTION
Fixes the following upstream dotland issues:

- [`bug: /x doesn't format markdown strikethroughs `](https://github.com/denoland/dotland/issues/2217).
- [`HTML5 details/summary not rendering correctly`](https://github.com/denoland/dotland/issues/2059).