### PR TITLE
Bump dependencies

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -5,12 +5,12 @@
 /// <reference lib="deno.ns" />
 /// <reference lib="deno.unstable" />
 
-export { emojify } from "https://deno.land/x/emoji@0.1.2/mod.ts";
+export { emojify } from "https://deno.land/x/emoji@0.2.1/mod.ts";
 
-export * as Marked from "https://esm.sh/marked@4.0.12";
+export * as Marked from "https://esm.sh/marked@4.2.5";
 
-export { default as Prism } from "https://esm.sh/prismjs@1.27.0";
+export { default as Prism } from "https://esm.sh/prismjs@1.29.0";
 
-export { default as sanitizeHtml } from "https://esm.sh/sanitize-html@2.7.0";
+export { default as sanitizeHtml } from "https://esm.sh/sanitize-html@2.8.1";
 
 export { escape as htmlEscape } from "https://esm.sh/he@1.2.0";

--- a/example/content.md
+++ b/example/content.md
@@ -11,6 +11,27 @@
 + world
 ```
 
+- Buildscript
+```ts
+import { build } from "https://deno.land/x/esbuild/mod.ts"
+import sassPlugin from "https://deno.land/x/esbuild_plugin_sass_deno/mod.ts"
+
+build({
+    entryPoints: [
+        "example/in.ts"
+    ],
+    bundle: true,
+    outfile: "example/out.js",
+    plugins: [sassPlugin()]
+})
+```
+- Main Entrypoint File:
+```ts
+import styles from "./styles.scss"
+
+document.getElementsByTagName("head")[0].innerHTML += `<style>${styles}</style>`
+```
+
 # Deno
 
 [![Build Status - Cirrus][]][Build status] [![Twitter handle][]][Twitter badge]


### PR DESCRIPTION
This bumps various dependencies in the project, which also happens to fix the following:

- [`Markdown Renderer fails to render codeblocks in lists.`](https://github.com/denoland/dotland/issues/2622)