### PR TITLE
bug fix: inline math

### DIFF
--- a/example/content.md
+++ b/example/content.md
@@ -61,6 +61,16 @@ When $a \ne 0$, there are two solutions to $(ax^2 + bx + c = 0)$ and they are
 
 $$ x = {-b \pm \sqrt{b^2-4ac} \over 2a} $$
 
+You can even typeset individual letters or whole sentences inline just like $x$ or $Quadratic \; formula$. You can also use math blocks to typeset whole equations with $\LaTeX$:
+
+$$
+\begin{aligned}
+\dot{x} & = \sigma(y-x) \\
+\dot{y} & = \rho x - y - xz \\
+\dot{z} & = -\beta z + xy
+\end{aligned}
+$$
+
 # Deno
 
 [![Build Status - Cirrus][]][Build status] [![Twitter handle][]][Twitter badge]

--- a/mod.ts
+++ b/mod.ts
@@ -69,7 +69,7 @@ function mathify(markdown: string) {
   }
 
   // Deal with inline math
-  const inlineMath = /\s\$(\S.+?\S)\$/;
+  const inlineMath = /\s\$((?=\S).*?(?=\S))\$/;
   while ((match = inlineMath.exec(markdown)) !== null) {
     markdown = markdown.replace(
       inlineMath,


### PR DESCRIPTION
The PR fixes a bug where Katex would error out if the content in an inline math block would have length less than 3.

For example:
Consider the following markdown snippet,

```md
This letter is typeset inline $x$. This is another inline math block $Quadratic \; Formula$.
```

This causes this error upon rendering:

```KaTeX parse error: Can't use function '$' in math mode at position 2: x$̲. This is anoth…```

Because the original regex `/\s\$(\S.+?\S)\$/` assumes that the content is non-empty, it is prefixed and suffixed by a necessary non-whitespace character.

The new regex `/\s\$((?=\S).*?(?=\S))\$/` takes care of this error by having positive lookup at the start and the end of the content.