### PR TITLE
allow `colspan` & `rowspan` attributes in `<td>` to fix broken table

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -199,6 +199,7 @@ export function render(markdown: string, opts: RenderOptions = {}): string {
       h4: ["id"],
       h5: ["id"],
       h6: ["id"],
+      td: ["colspan", "rowspan"],
       iframe: ["src", "width", "height"], // Only used when iframe tags are allowed in the first place.
       math: ["xmlns"], // Only enabled when math is enabled
       annotation: ["encoding"], // Only enabled when math is enabled


### PR DESCRIPTION
HTML table that contains merged cell in deno.land seems to be broken: https://deno.land/x/ua_parser_js

![table-deno](https://user-images.githubusercontent.com/460302/228574548-b42b41e9-56d2-4799-acc7-4edacd94cb95.png)

Compared with GitHub: https://github.com/faisalman/ua-parser-js

![table-github](https://user-images.githubusercontent.com/460302/228573728-02f9801c-07da-4124-8e7d-b00fc6021086.png)

And NPM: https://www.npmjs.com/package/ua-parser-js

![table-npm](https://user-images.githubusercontent.com/460302/228574725-5eff8d3f-cc10-42ba-9189-ffe7e13e586c.png)

This can be fixed by allowing `colspan` & `rowspan` attribute to be used in `<td>`

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#colspan