### PR TITLE
chore: update dependencies

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -7,9 +7,11 @@
 
 export { emojify } from "https://deno.land/x/emoji@0.3.0/mod.ts";
 
-export * as Marked from "https://esm.sh/marked@5.1.0/";
+export * as Marked from "https://esm.sh/marked@9.1.1/";
 
-export { gfmHeadingId } from "https://esm.sh/marked-gfm-heading-id@3.0.4/";
+export { default as GitHubSlugger } from "https://esm.sh/github-slugger@2.0.0/";
+
+export { gfmHeadingId } from "https://esm.sh/marked-gfm-heading-id@3.1.0/";
 
 export { default as Prism } from "https://esm.sh/prismjs@1.29.0";
 

--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,7 @@
 import {
   emojify,
   gfmHeadingId,
+  GitHubSlugger,
   htmlEscape,
   katex,
   Marked,
@@ -12,11 +13,15 @@ export { CSS, KATEX_CSS, Marked };
 
 Marked.marked.use(gfmHeadingId());
 
+const slugger = new GitHubSlugger();
+
 export class Renderer extends Marked.Renderer {
   allowMath: boolean;
+  baseUrl: string | undefined;
 
   constructor(options: Marked.marked.MarkedOptions & RenderOptions = {}) {
     super(options);
+    this.baseUrl = options.baseUrl;
     this.allowMath = options.allowMath ?? false;
   }
 
@@ -24,7 +29,6 @@ export class Renderer extends Marked.Renderer {
     text: string,
     level: 1 | 2 | 3 | 4 | 5 | 6,
     raw: string,
-    slugger: Marked.Slugger,
   ): string {
     const slug = slugger.slug(raw);
     return `<h${level} id="${slug}"><a class="anchor" aria-hidden="true" tabindex="-1" href="#${slug}"><svg class="octicon octicon-link" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>${text}</h${level}>`;
@@ -59,9 +63,9 @@ export class Renderer extends Marked.Renderer {
     if (href.startsWith("#")) {
       return `<a href="${href}"${titleAttr}>${text}</a>`;
     }
-    if (this.options.baseUrl) {
+    if (this.baseUrl) {
       try {
-        href = new URL(href, this.options.baseUrl).href;
+        href = new URL(href, this.baseUrl).href;
       } catch (_) {
         //
       }


### PR DESCRIPTION
This updates most of the dependencies to latest. `marked` in particular had a few version jumps and moved some stuff into external libraries.

This will resolve the annoying `baseUrl` is deprecated warning we're seeing in some projects.