### PR TITLE
fix: update video allowed attributes

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -213,6 +213,7 @@ export function render(markdown: string, opts: RenderOptions = {}): string {
         "loop",
         "playsinline",
         "poster",
+        "controls",
       ],
       a: ["id", "aria-hidden", "href", "tabindex", "rel", "target"],
       svg: ["viewbox", "width", "height", "aria-hidden", "background"],


### PR DESCRIPTION
Adds the `controls` attribute to the list of `allowedAttributes` for a `video` element.