### PR TITLE
fix: make deps vendorable and pin esm.sh deps

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -7,16 +7,16 @@
 
 export { emojify } from "https://deno.land/x/emoji@0.3.0/mod.ts";
 
-export * as Marked from "https://esm.sh/marked@9.1.1/";
+export * as Marked from "https://esm.sh/marked@9.1.1?pin=v135";
 
-export { default as GitHubSlugger } from "https://esm.sh/github-slugger@2.0.0/";
+export { default as GitHubSlugger } from "https://esm.sh/github-slugger@2.0.0?pin=v135";
 
-export { gfmHeadingId } from "https://esm.sh/marked-gfm-heading-id@3.1.0/";
+export { gfmHeadingId } from "https://esm.sh/marked-gfm-heading-id@3.1.0?pin=v135";
 
-export { default as Prism } from "https://esm.sh/prismjs@1.29.0";
+export { default as Prism } from "https://esm.sh/prismjs@1.29.0?pin=v135";
 
-export { default as sanitizeHtml } from "https://esm.sh/sanitize-html@2.8.1?target=esnext";
+export { default as sanitizeHtml } from "https://esm.sh/sanitize-html@2.8.1?target=esnext&pin=v135";
 
-export { escape as htmlEscape } from "https://esm.sh/he@1.2.0";
+export { escape as htmlEscape } from "https://esm.sh/he@1.2.0?pin=v135";
 
-export { default as katex } from "https://esm.sh/katex@0.16.8/dist/katex.mjs";
+export { default as katex } from "https://esm.sh/katex@0.16.8/dist/katex.mjs?pin=v135";


### PR DESCRIPTION
It seems specifiers can't be vendored if they have a trailing slash and resolve to a file path.