### PR TITLE
chore: bump deps

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -7,18 +7,18 @@
 
 export { emojify } from "https://deno.land/x/emoji@0.3.0/mod.ts";
 
-export * as Marked from "https://esm.sh/marked@9.1.1?pin=v135";
+export * as Marked from "https://esm.sh/marked@11.1.1?pin=v135";
 
 export { default as GitHubSlugger } from "https://esm.sh/github-slugger@2.0.0?pin=v135";
 
 export { default as markedAlert } from "https://esm.sh/marked-alert@2.0.1?pin=v135";
 
-export { gfmHeadingId } from "https://esm.sh/marked-gfm-heading-id@3.1.0?pin=v135";
+export { gfmHeadingId } from "https://esm.sh/marked-gfm-heading-id@3.1.2?pin=v135";
 
 export { default as Prism } from "https://esm.sh/prismjs@1.29.0?pin=v135";
 
-export { default as sanitizeHtml } from "https://esm.sh/sanitize-html@2.8.1?target=esnext&pin=v135";
+export { default as sanitizeHtml } from "https://esm.sh/sanitize-html@2.11.0?target=esnext&pin=v135";
 
 export { escape as htmlEscape } from "https://esm.sh/he@1.2.0?pin=v135";
 
-export { default as katex } from "https://esm.sh/katex@0.16.8/dist/katex.mjs?pin=v135";
+export { default as katex } from "https://esm.sh/katex@0.16.9/dist/katex.mjs?pin=v135";

--- a/mod.ts
+++ b/mod.ts
@@ -21,7 +21,7 @@ export class Renderer extends Marked.Renderer {
   allowMath: boolean;
   baseUrl: string | undefined;
 
-  constructor(options: Marked.marked.MarkedOptions & RenderOptions = {}) {
+  constructor(options: Marked.MarkedOptions & RenderOptions = {}) {
     super(options);
     this.baseUrl = options.baseUrl;
     this.allowMath = options.allowMath ?? false;
@@ -126,11 +126,13 @@ export function render(markdown: string, opts: RenderOptions = {}): string {
     gfm: true,
     mangle: false,
     renderer: opts.renderer ? opts.renderer : new Renderer(opts),
+    async: false,
   };
 
-  const html = opts.inline
-    ? Marked.marked.parseInline(markdown, marked_opts)
-    : Marked.marked.parse(markdown, marked_opts);
+  const html =
+    (opts.inline
+      ? Marked.marked.parseInline(markdown, marked_opts)
+      : Marked.marked.parse(markdown, marked_opts)) as string;
 
   if (opts.disableHtmlSanitization) {
     return html;


### PR DESCRIPTION
As per https://github.com/markedjs/marked/pull/3103#issuecomment-1831377190, we now need to explicitly set `async: false` and cast `as string` if we want to maintain the same API. Because the types were previously broken, I guess this isn't too bad.