### PR TITLE
chore: check entire project in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Run lint
         run: |
           deno lint
-      - name: Check mod.ts
+      - name: Check project
         run: |
-          deno check mod.ts
+          deno task check:types
       - name: Run tests
         run: |
           deno task test


### PR DESCRIPTION
@hashrock, this is an easy one. We should start type checking the entire project.