### PR TITLE
chore: refactor server tests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -6,6 +6,7 @@
     "dev": "deno run -A --unstable --watch --no-check ./example/main.ts",
     "ok": "deno fmt --check && deno lint && deno task check:types && deno task test",
     "report": "deno coverage cov_profile --html",
+    "server": "deno run -A --watch=test/,mod.ts ./test/runTestServer.ts",
     "test": "deno test --allow-read --allow-env --allow-write --allow-run --allow-net"
   },
   "fmt": {

--- a/test/runTestServer.ts
+++ b/test/runTestServer.ts
@@ -1,0 +1,2 @@
+import { startServer } from "./test_utils.ts";
+startServer();

--- a/test/server_test.ts
+++ b/test/server_test.ts
@@ -1,22 +1,8 @@
 import { assert } from "./test_deps.ts";
-import { render } from "../mod.ts";
-import { browserTest, setupHtmlWithCss } from "./test_utils.ts";
+import { browserTest } from "./test_utils.ts";
 
 Deno.test("basic md table with dollar signs", async () => {
-  const markdown = `| Fruit Name | Quantity | Unit Cost per Item | Subtotal |
-  |------------|----------|--------------------|----------|
-  | Apple      | 1        | $1.50              | $1.50    |
-  | Pear       | 2        | $2.00              | $4.00    |
-  | Orange     | 3        | $2.50              | $7.50    |
-  | Grape      | 60       | $0.05              | $3.00    |
-  | Total      |          |                    | $16.00   |`;
-
-  const body = render(markdown);
-  const html = setupHtmlWithCss(body);
-
-  await browserTest(html, async (page, address) => {
-    await page.goto(`${address}`);
-
+  await browserTest("basicMarkdownTable", async (page) => {
     await page.waitForSelector("table", { timeout: 1000 });
     const tableExists = await page.evaluate(() => {
       const table = document.querySelector("table");
@@ -64,7 +50,7 @@ Deno.test("basic md table with dollar signs", async () => {
           if (!element) {
             return null;
           }
-          const style = window.getComputedStyle(element);
+          const style = globalThis.getComputedStyle(element);
           return style[property];
         },
         selector,


### PR DESCRIPTION
@crowlKats, would you be able to take a look? I pulled this code out of https://github.com/denoland/deno-gfm/pull/96 since it's not directly related to yaml. Once this PR is merged, I'll go back to the following and refactor them to use this new pattern:
* https://github.com/denoland/deno-gfm/pull/96
* https://github.com/denoland/deno-gfm/pull/94

The point of this change is to make it easier to define test cases that should verify css and have a way to visually inspect the case. I've done this by introducing a `server` task that allows the developer to browse a list of cases and view them.