### PR TITLE
fix: support task lists

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -293,7 +293,10 @@ export function render(markdown: string, opts: RenderOptions = {}): string {
     annotation: ["encoding"], // Only enabled when math is enabled
     details: ["open"],
     section: ["data-footnotes"],
-    input: ["type", "checked", "disabled"],
+    input: ["checked", "disabled", {
+      name: "type",
+      values: ["checkbox"],
+    }],
   };
 
   return sanitizeHtml(html, {

--- a/mod.ts
+++ b/mod.ts
@@ -156,6 +156,7 @@ export function render(markdown: string, opts: RenderOptions = {}): string {
     "del",
     "details",
     "summary",
+    "input",
   ]);
   if (opts.allowIframes) {
     defaultAllowedTags.push("iframe");
@@ -292,6 +293,7 @@ export function render(markdown: string, opts: RenderOptions = {}): string {
     annotation: ["encoding"], // Only enabled when math is enabled
     details: ["open"],
     section: ["data-footnotes"],
+    input: ["type", "checked", "disabled"],
   };
 
   return sanitizeHtml(html, {

--- a/test/fixtures/taskList.html
+++ b/test/fixtures/taskList.html
@@ -1,0 +1,5 @@
+<ul>
+<li>Normal list</li>
+<li><input checked disabled type="checkbox" /> done</li>
+<li><input disabled type="checkbox" /> not done</li>
+</ul>

--- a/test/test.ts
+++ b/test/test.ts
@@ -346,3 +346,13 @@ Deno.test("details, summary, and del", () => {
   const html = render(markdown);
   assertEquals(html, expected.trim());
 });
+
+Deno.test("task list", () => {
+  const markdown = `- Normal list
+- [x] done
+- [ ] not done`;
+  const expected = Deno.readTextFileSync("./test/fixtures/taskList.html");
+
+  const html = render(markdown);
+  assertEquals(html, expected);
+});


### PR DESCRIPTION
closes https://github.com/denoland/deno-gfm/issues/104

This is a pretty common feature, so I thought we should support it by default. (As opposed to custom tags/attributes, via https://github.com/denoland/deno-gfm/pull/95.)

The problem was that the output was getting sanitized away by the sanitizer. Now we'll stop doing that.