### PR TITLE
fix: broken package / import assertion

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -11,10 +11,10 @@
     "marked-gfm-heading-id": "npm:marked-gfm-heading-id@^3.1",
     "prismjs": "npm:prismjs@^1.29",
     "prismjs-yaml": "npm:prismjs@^1.29/components/prism-yaml.js",
-    "sanitize-html": "npm:sanitize-html@^2.11",
+    "sanitize-html": "npm:sanitize-html@^2.13",
     "he": "npm:he@^1.2",
     "katex": "npm:katex@^0.16",
-    "@std/assert": "jsr:@std/assert@^0.214"
+    "@std/assert": "jsr:@std/assert@^1.0"
   },
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "dom.asynciterable", "deno.ns"]

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,7 @@
   "version": "0.9.0",
   "exports": "./mod.ts",
   "imports": {
-    "emoji": "jsr:@denosaurs/emoji@0.3",
+    "emoji": "jsr:@denosaurs/emoji@^0.3",
     "marked": "npm:marked@^12",
     "github-slugger": "npm:github-slugger@^2.0",
     "marked-alert": "npm:marked-alert@^2.0",

--- a/example/main.ts
+++ b/example/main.ts
@@ -53,7 +53,7 @@ async function handler(_req: Request): Promise<Response> {
     });
   } catch (err) {
     console.error(err);
-    return new Response(err.message, { status: 500 });
+    return new Response((err as Error).message, { status: 500 });
   }
 }
 

--- a/mod.ts
+++ b/mod.ts
@@ -39,16 +39,16 @@ export class Renderer extends Marked.Renderer {
     this.#slugger = new GitHubSlugger();
   }
 
-  heading(text: string, level: 1 | 2 | 3 | 4 | 5 | 6, raw: string): string {
+  override heading(text: string, level: 1 | 2 | 3 | 4 | 5 | 6, raw: string): string {
     const slug = this.#slugger.slug(raw);
     return `<h${level} id="${slug}"><a class="anchor" aria-hidden="true" tabindex="-1" href="#${slug}"><svg class="octicon octicon-link" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>${text}</h${level}>\n`;
   }
 
-  image(src: string, title: string | null, alt: string): string {
+  override image(src: string, title: string | null, alt: string): string {
     return `<img src="${src}" alt="${alt}" title="${title ?? ""}" />`;
   }
 
-  code(code: string, language?: string): string {
+  override code(code: string, language?: string): string {
     const isTitleIncluded = language?.match(/\stitle="(.+)"/);
     let title = null;
     if (isTitleIncluded) {
@@ -79,7 +79,7 @@ export class Renderer extends Marked.Renderer {
     return `<div class="highlight highlight-source-${language} notranslate">${titleHtml}<pre>${html}</pre></div>`;
   }
 
-  link(href: string, title: string | null, text: string): string {
+  override link(href: string, title: string | null, text: string): string {
     const titleAttr = title ? ` title="${title}"` : "";
     if (href.startsWith("#")) {
       return `<a href="${href}"${titleAttr}>${text}</a>`;
@@ -463,7 +463,7 @@ function stripTokens(
 }
 
 class StripTokenizer extends Marked.Tokenizer {
-  codespan(src: string): Marked.Tokens.Codespan | undefined {
+  override codespan(src: string): Marked.Tokens.Codespan | undefined {
     // copied & modified from Marked to remove escaping
     const cap = this.rules.inline.code.exec(src);
     if (cap) {

--- a/mod.ts
+++ b/mod.ts
@@ -39,7 +39,11 @@ export class Renderer extends Marked.Renderer {
     this.#slugger = new GitHubSlugger();
   }
 
-  override heading(text: string, level: 1 | 2 | 3 | 4 | 5 | 6, raw: string): string {
+  override heading(
+    text: string,
+    level: 1 | 2 | 3 | 4 | 5 | 6,
+    raw: string,
+  ): string {
     const slug = this.#slugger.slug(raw);
     return `<h${level} id="${slug}"><a class="anchor" aria-hidden="true" tabindex="-1" href="#${slug}"><svg class="octicon octicon-link" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>${text}</h${level}>\n`;
   }

--- a/test/test.ts
+++ b/test/test.ts
@@ -93,7 +93,7 @@ Deno.test("custom renderer", () => {
   const expected = `<h1 id="custom-renderer">hello world</h1>`;
 
   class CustomRenderer extends Renderer {
-    heading(text: string, level: 1 | 2 | 3 | 4 | 5 | 6): string {
+    override heading(text: string, level: 1 | 2 | 3 | 4 | 5 | 6): string {
       return `<h${level} id="custom-renderer">${text}</h${level}>`;
     }
   }
@@ -229,7 +229,7 @@ Deno.test("custom allowed classes", async () => {
     "./test/fixtures/customAllowedClasses.html",
   );
   class CustomRenderer extends Renderer {
-    list(body: string, ordered: boolean): string {
+    override list(body: string, ordered: boolean): string {
       const type = ordered ? "list-decimal" : "list-disc";
       const tag = ordered ? "ol" : "ul";
       return `<${tag} class="${type}">${body}</${tag}>`;


### PR DESCRIPTION
This package is currently broken on Deno v2

Dependency emoji v0.3.0 uses a legacy import assertion 
`import emojis from "./all.json" assert { type: "json" };`
which Deno 2 now exits with an error.

This is fixed in [v0.3.1](https://github.com/denosaurs/emoji/commit/6b9872c50a19c6de6bce5fa23a30573a9fbaa1b4) by @lino-levan with the `with { type: "json" }` syntax. 

This PR updates the dependency pinning to pull the correct version in. 

Verified & tested it now runs as expected locally.