### PR TITLE
Update emoji dependency to v0.3.1 to fix deprecated import assertion

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,7 @@
   "version": "0.10.0",
   "exports": "./mod.ts",
   "imports": {
-    "emoji": "jsr:@denosaurs/emoji@^0.3",
+    "emoji": "jsr:@denosaurs/emoji@^0.3.1",
     "marked": "npm:marked@^12",
     "github-slugger": "npm:github-slugger@^2.0",
     "marked-alert": "npm:marked-alert@^2.0",


### PR DESCRIPTION
Hi deno-gfm team,

I encountered an error when using deno-gfm with the latest Deno version:error: Uncaught TypeError: Import assertions are deprecated. Use `with` keyword...
import emojis from "./all.json" assert { type: "json" };This issue originates from the dependency emoji@0.3.0 which uses deprecated syntax. The problem has been fixed in emoji@0.3.1 (see denosaurs/emoji#16).Please update the dependency in deno-gfm to:"emoji": "jsr:@denosaurs/emoji@^0.3.1". If needed, I'm happy to submit a PR for this change.